### PR TITLE
Fix ID generation to avoid magic numbers

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def get_item(item_id):
 @app.route('/items', methods=['POST'])
 def add_item():
     new_item = request.json
-    new_item['id'] = len(data) + 1  # Magic number issue
+    new_item['id'] = max([item['id'] for item in data], default=0) + 1
     data.append(new_item)
     return jsonify(new_item), 201
 

--- a/main.py
+++ b/main.py
@@ -8,10 +8,8 @@ data = [
 ]
 
 def find_item_by_id(item_id):
-    for item in data:  # Long function issue
-        if item['id'] == item_id:
-            return item
-    return None
+    return next((item for item in data if item['id'] == item_id), None)
+
 
 @app.route('/')
 def home():


### PR DESCRIPTION
This PR fixes the issue of using a magic number in ID generation.
Previously, len(data) + 1 was used, which could lead to duplicate IDs if an item was deleted.
Now, the ID is generated using max() to ensure uniqueness.

Before:
`new_item['id'] = len(data) + 1`

After:
`new_item['id'] = max([item['id'] for item in data], default=0) + 1`